### PR TITLE
feat: add let-bindings and variables support to interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ ROBERTO ALSO HAS A CLI
 
 ROBERTO IS HELPING ME TO UNDERSTAND COMPILERS, INTERPRETERS AND OCAML 
 ROBERTO IS MY IMAGINARY FRIEND THAT HELPS ME LEARN AND EXPLORE NEW IDEAS. 
+
+
+# About the lannguage 
+By now everything will be an expression.
+
+
+# Learning notes
+## Precedence and associativity

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -28,7 +28,8 @@ let run_file (filename : string) =
     MenhirLib.Convert.Simplified.traditional2revised Roberto_lib.Parser.main
   in
   try
-    let result = parser lexer in
+    let ast = parser lexer in
+    let result = Roberto_lib.Eval.eval [] ast in
     print_float result;
     print_newline ()
   with
@@ -46,7 +47,8 @@ let repl () =
       MenhirLib.Convert.Simplified.traditional2revised Roberto_lib.Parser.main
     in
     try
-      let result = parser lexer in
+      let ast = parser lexer in
+      let result = Roberto_lib.Eval.eval [] ast in
       print_float result;
       print_newline ();
       flush stdout

--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -1,0 +1,8 @@
+type expr =
+  | Num of float
+  | Var of string
+  | Let of string * expr * expr
+  | Add of expr * expr
+  | Sub of expr * expr
+  | Mul of expr * expr
+  | Div of expr * expr

--- a/lib/eval.ml
+++ b/lib/eval.ml
@@ -1,0 +1,16 @@
+open Ast
+
+type env = (string * float) list
+
+let rec eval env = function
+  | Num n -> n
+  | Var id -> (
+      try List.assoc id env
+      with Not_found -> failwith ("Undefined variable: " ^ id))
+  | Let (id, e1, e2) ->
+      let v1 = eval env e1 in
+      eval ((id, v1) :: env) e2
+  | Add (e1, e2) -> eval env e1 +. eval env e2
+  | Sub (e1, e2) -> eval env e1 -. eval env e2
+  | Mul (e1, e2) -> eval env e1 *. eval env e2
+  | Div (e1, e2) -> eval env e1 /. eval env e2

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -1,20 +1,38 @@
 // tokens
 %token <float> NUMBER
+%token <string> ID
+%token EQUAL
 %token PLUS
+%token MINUS
+%token STAR
+%token SLASH
 %token EOF
 %token LEFT_PAREN RIGHT_PAREN
+%token LET VAR ASSIGN IN END
 
 // Precedence and associativity
-%left PLUS
+%left PLUS MINUS
+%left STAR SLASH
 
 // Start symbol
-%start <float> main
+%start <Ast.expr> main
 %%
 
 main:
     | expr EOF {$1}
 
 expr:
-    | NUMBER {$1}
-    | expr PLUS expr {$1 +. $3}
+    | NUMBER {Ast.Num $1}
+    | ID { Ast.Var $1 }
+    | LET vardec IN expr END {
+        let (id, value_expr) = $2 in
+        Ast.Let(id, value_expr, $4)
+    }
+    | expr PLUS expr { Ast.Add($1, $3) }
+    | expr MINUS expr { Ast.Sub($1, $3) }
+    | expr STAR expr { Ast.Mul($1, $3) }
+    | expr SLASH expr { Ast.Div($1, $3) }
     | LEFT_PAREN expr RIGHT_PAREN {$2}
+
+vardec:
+    | VAR ID ASSIGN expr { ($2, $4) }

--- a/roberto.ox
+++ b/roberto.ox
@@ -1,1 +1,5 @@
-1 + 1
+  let var x := 5 in
+    let var y := 3 in
+      x + y
+    end
+  end


### PR DESCRIPTION
Implement expression-based language with lexically scoped let-bindings `let var id := expr in expr end`

Also, AST module (Num, Var, Let, Add, Sub, Mul, Div. Updated parser to build AST instead of direct evaluation